### PR TITLE
Added scientific and common name to view of species with >5% detection rate

### DIFF
--- a/src/single-season-models/spOccupancy-TEMPLATE.R
+++ b/src/single-season-models/spOccupancy-TEMPLATE.R
@@ -61,7 +61,8 @@ detects <- detects %>%
 # of nobs [camera locations * sampling occasion] with species detection)
 detects %>% 
   dplyr::filter(propdetect >= 0.05) %>%
-  select(c(spp, nobs, propdetect))
+  left_join(species,by=c("spp"="Species_code")) %>%
+  select(c(spp, Species, Common_name, nobs, propdetect))
 
 # Select species of interest (ideally with a detection rate of at least 5%)
 SPECIES <- "CALA"


### PR DESCRIPTION
Simple tweak to code to include scientific and common names, in addition to species code, to the view of species with at least 5% detection rate.