### PR TITLE
Updates to include burn severity for single season models at CHIR

### DIFF
--- a/data/covariates/covariates.csv
+++ b/data/covariates/covariates.csv
@@ -12,7 +12,7 @@ either,all,slope2,slope_z + I(slope_z^2),Slope (degrees)
 either,all,trail,trail_z,Distance to nearest trail (m)
 either,all,roadbound,roadbound_z,Distance to nearest road or unprotected boundary (m)
 either,all,trailpoi,trailpoi_z,Distance to nearest trail or point of interest (m)
-either,CHIR,burn,burn_severity,Burn severity
+either,CHIR,burn,burn_severity_2011,Burn severity
 either,SAGW,wash,wash_z,Distance to nearest wash (m)
 either,SAGW,veg,vegclass2 + vegclass3,NA
 detection,all,day,day_z,Day of the year

--- a/src/functions.R
+++ b/src/functions.R
@@ -331,7 +331,7 @@ marginal_plot_occ <- function(covariate,
                           cent = preds_cent,
                           lcl = preds_lcl,
                           ucl = preds_ucl)
-  cov_name <- str_remove(covariate, "_z")
+  cov_name <- ifelse(covariate=="burn_severity_2011","burn",str_remove(covariate, "_z"))
   
   cred_interval <- (upper_ci - lower_ci) * 100
   yaxis_label <- paste0("Predicted occurrence probability (", 
@@ -422,7 +422,7 @@ marginal_plot_det <- function(covariate,
                           cent = preds_cent,
                           lcl = preds_lcl,
                           ucl = preds_ucl)
-  cov_name <- str_remove(covariate, "_z")
+  cov_name <- ifelse(covariate=="burn_severity_2011","burn",str_remove(covariate, "_z"))
   
   cred_interval <- (upper_ci - lower_ci) * 100
   yaxis_label <- paste0("Predicted detection probability (", 

--- a/src/single-season-models/spOccupancy-TEMPLATE.R
+++ b/src/single-season-models/spOccupancy-TEMPLATE.R
@@ -67,6 +67,8 @@ detects %>%
 # Select species of interest (ideally with a detection rate of at least 5%)
 SPECIES <- "PETA"
 
+# Save this script as: src/single-season-models/YEAR/spOccupancy-PARK-SPECIES-YEAR.R
+
 #------------------------------------------------------------------------------#
 # Prepare detection and covariate data to run occupancy models with spOccupancy
 #------------------------------------------------------------------------------#
@@ -381,7 +383,7 @@ if (length(psi_covs) > 0) {
 # constant)
 #------------------------------------------------------------------------------#
 
-# Identify continuous covariates in occurrence part of the best model
+# Identify continuous covariates in detection part of the best model
 p_continuous <- p_covs_z[p_covs_z != "1"]
 p_cont_unique <- unique(p_continuous)
 p_n_cont <- length(p_cont_unique)
@@ -397,7 +399,8 @@ p_n_cont <- length(p_cont_unique)
              marginal_plot_det(covariate = cov, 
                                model = best, 
                                data_list = data_list,
-                               covariate_table = covariates))
+                               covariate_table = covariates,
+                               central_meas = mean))
     } 
   }
 # Can view these plots, calling them by name. Available plots listed here:

--- a/src/single-season-models/spOccupancy-data-prep.R
+++ b/src/single-season-models/spOccupancy-data-prep.R
@@ -243,7 +243,7 @@ det_covs <- list(day_z = day_z,
                  trailpoi_z = spatial_covs$trailpoi_z)
 if (PARK == "CHIR") {
   det_covs <- c(det_covs, 
-                list(burn_severity = spatial_covs$burn_severity_2011))
+                list(burn_severity_2011 = spatial_covs$burn_severity_2011))
 }
 if (PARK == "SAGW") {
   det_covs <- c(det_covs, 


### PR DESCRIPTION
Slight tweaks to account for non-standard naming of burn severity co-variate. Addition of central_meas to marginal_plot_det() call in TEMPLATE to get function to run. Only tested with single-season model code for one species each at CHIR and SAGW. Did not test with multi-season model code for CHIR because was running into other issues (missing weather covariates).